### PR TITLE
Merge pansn-sparsification into main, update fastga-rs

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -616,7 +616,7 @@ dependencies = [
 [[package]]
 name = "fastga-rs"
 version = "0.1.2"
-source = "git+https://github.com/pangenome/fastga-rs?rev=eb50026#eb50026cae4d7b114dfa2466e35bf13e41c94a52"
+source = "git+https://github.com/pangenome/fastga-rs?rev=2da9567#2da95679886f8d5674406ae444494ac3022afda1"
 dependencies = [
  "anyhow",
  "cc",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -659,12 +659,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3f9eec918d3f24069decb9af1554cad7c880e2da24a9afd88aca000531ab82c1"
 
 [[package]]
-name = "foldhash"
-version = "0.1.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d9c4f5dac5e15c24eb999c26181a6ca40b39fe946cbe4c263c7209467bc83af2"
-
-[[package]]
 name = "form_urlencoded"
 version = "1.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -711,21 +705,8 @@ checksum = "899def5c37c4fd7b2664648c28120ecec138e4d395b459e5ca34f9cce2dd77fd"
 dependencies = [
  "cfg-if",
  "libc",
- "r-efi 5.3.0",
+ "r-efi",
  "wasip2",
-]
-
-[[package]]
-name = "getrandom"
-version = "0.4.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0de51e6874e94e7bf76d726fc5d13ba782deca734ff60d5bb2fb2607c7406555"
-dependencies = [
- "cfg-if",
- "libc",
- "r-efi 6.0.0",
- "wasip2",
- "wasip3",
 ]
 
 [[package]]
@@ -753,15 +734,6 @@ checksum = "e5274423e17b7c9fc20b6e7e208532f9b19825d82dfd615708b70edd83df41f1"
 dependencies = [
  "ahash",
  "allocator-api2",
-]
-
-[[package]]
-name = "hashbrown"
-version = "0.15.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9229cfe53dfd69f0609a49f65461bd93001ea1ef889cd5529dd176593f5338a1"
-dependencies = [
- "foldhash",
 ]
 
 [[package]]
@@ -903,12 +875,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "id-arena"
-version = "2.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3d3067d79b975e8844ca9eb072e16b31c3c1c36928edf9c6789548c524d0d954"
-
-[[package]]
 name = "idna"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -943,8 +909,6 @@ checksum = "d466e9454f08e4a911e14806c24e16fba1b4c121d1ea474396f396069cf949d9"
 dependencies = [
  "equivalent",
  "hashbrown 0.17.0",
- "serde",
- "serde_core",
 ]
 
 [[package]]
@@ -1043,12 +1007,6 @@ name = "lazycell"
 version = "1.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "830d08ce1d1d941e6b30645f1a0eb5643013d835ce3779a5fc208261dbe10f55"
-
-[[package]]
-name = "leb128fmt"
-version = "0.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "09edd9e8b54e49e587e4f6295a7d29c3ea94d469cb40ab8ca70b288248a81db2"
 
 [[package]]
 name = "libc"
@@ -1366,16 +1324,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "prettyplease"
-version = "0.2.37"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "479ca8adacdd7ce8f1fb39ce9ecccbfe93a3f1344b3d0d97f20bc0196208f62b"
-dependencies = [
- "proc-macro2",
- "syn",
-]
-
-[[package]]
 name = "proc-macro2"
 version = "1.0.106"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1423,12 +1371,6 @@ name = "r-efi"
 version = "5.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "69cdb34c158ceb288df11e18b4bd39de994f6657d83847bdffdbd7f346754b0f"
-
-[[package]]
-name = "r-efi"
-version = "6.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f8dcc9c7d52a811697d2151c701e0d08956f92b0e24136cf4cf27b57a6a0d9bf"
 
 [[package]]
 name = "ragc-common"
@@ -1645,7 +1587,7 @@ version = "0.1.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c5f5376ea5e30ce23c03eb77cbe4962b988deead10910c372b226388b594c084"
 dependencies = [
- "semver 0.1.20",
+ "semver",
 ]
 
 [[package]]
@@ -1699,12 +1641,6 @@ name = "semver"
 version = "0.1.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d4f410fedcf71af0345d7607d246e7ad15faaadd49d240ee3b24e5dc21a820ac"
-
-[[package]]
-name = "semver"
-version = "1.0.28"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8a7852d02fc848982e0c167ef163aaff9cd91dc640ba85e263cb1ce46fae51cd"
 
 [[package]]
 name = "serde"
@@ -1862,7 +1798,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32497e9a4c7b38532efcdebeef879707aa9f794296a4f0244f6f69e9bc8574bd"
 dependencies = [
  "fastrand",
- "getrandom 0.4.2",
+ "getrandom 0.3.4",
  "once_cell",
  "rustix",
  "windows-sys",
@@ -1967,12 +1903,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e6e4313cd5fcd3dad5cafa179702e2b244f760991f45397d14d4ebf38247da75"
 
 [[package]]
-name = "unicode-xid"
-version = "0.2.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ebc1c04c71510c7f702b52b7c350734c9ff1295c464a03335b00bb84fc54f853"
-
-[[package]]
 name = "url"
 version = "2.5.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2052,15 +1982,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "wasip3"
-version = "0.4.0+wasi-0.3.0-rc-2026-01-06"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5428f8bf88ea5ddc08faddef2ac4a67e390b88186c703ce6dbd955e1c145aca5"
-dependencies = [
- "wit-bindgen",
-]
-
-[[package]]
 name = "wasm-bindgen"
 version = "0.2.118"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2106,40 +2027,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "wasm-encoder"
-version = "0.244.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "990065f2fe63003fe337b932cfb5e3b80e0b4d0f5ff650e6985b1048f62c8319"
-dependencies = [
- "leb128fmt",
- "wasmparser",
-]
-
-[[package]]
-name = "wasm-metadata"
-version = "0.244.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bb0e353e6a2fbdc176932bbaab493762eb1255a7900fe0fea1a2f96c296cc909"
-dependencies = [
- "anyhow",
- "indexmap",
- "wasm-encoder",
- "wasmparser",
-]
-
-[[package]]
-name = "wasmparser"
-version = "0.244.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "47b807c72e1bac69382b3a6fb3dbe8ea4c0ed87ff5629b8685ae6b9a611028fe"
-dependencies = [
- "bitflags",
- "hashbrown 0.15.5",
- "indexmap",
- "semver 1.0.28",
-]
-
-[[package]]
 name = "web-sys"
 version = "0.3.95"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2152,7 +2039,7 @@ dependencies = [
 [[package]]
 name = "wfmash-rs"
 version = "0.1.0"
-source = "git+https://github.com/pangenome/wfmash-rs?rev=d47b7e3e#d47b7e3eba7f1d0f2bfdb72629cc667c2d5f8382"
+source = "git+https://github.com/pangenome/wfmash-rs?rev=3cc667743d59eca4f9fae0ea3fa9d4ee8b5a3ad6#3cc667743d59eca4f9fae0ea3fa9d4ee8b5a3ad6"
 dependencies = [
  "anyhow",
  "num_cpus",
@@ -2242,88 +2129,6 @@ name = "wit-bindgen"
 version = "0.51.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d7249219f66ced02969388cf2bb044a09756a083d0fab1e566056b04d9fbcaa5"
-dependencies = [
- "wit-bindgen-rust-macro",
-]
-
-[[package]]
-name = "wit-bindgen-core"
-version = "0.51.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ea61de684c3ea68cb082b7a88508a8b27fcc8b797d738bfc99a82facf1d752dc"
-dependencies = [
- "anyhow",
- "heck",
- "wit-parser",
-]
-
-[[package]]
-name = "wit-bindgen-rust"
-version = "0.51.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b7c566e0f4b284dd6561c786d9cb0142da491f46a9fbed79ea69cdad5db17f21"
-dependencies = [
- "anyhow",
- "heck",
- "indexmap",
- "prettyplease",
- "syn",
- "wasm-metadata",
- "wit-bindgen-core",
- "wit-component",
-]
-
-[[package]]
-name = "wit-bindgen-rust-macro"
-version = "0.51.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0c0f9bfd77e6a48eccf51359e3ae77140a7f50b1e2ebfe62422d8afdaffab17a"
-dependencies = [
- "anyhow",
- "prettyplease",
- "proc-macro2",
- "quote",
- "syn",
- "wit-bindgen-core",
- "wit-bindgen-rust",
-]
-
-[[package]]
-name = "wit-component"
-version = "0.244.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9d66ea20e9553b30172b5e831994e35fbde2d165325bec84fc43dbf6f4eb9cb2"
-dependencies = [
- "anyhow",
- "bitflags",
- "indexmap",
- "log",
- "serde",
- "serde_derive",
- "serde_json",
- "wasm-encoder",
- "wasm-metadata",
- "wasmparser",
- "wit-parser",
-]
-
-[[package]]
-name = "wit-parser"
-version = "0.244.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ecc8ac4bc1dc3381b7f59c34f00b67e18f910c2c0f50015669dde7def656a736"
-dependencies = [
- "anyhow",
- "id-arena",
- "indexmap",
- "log",
- "semver 1.0.28",
- "serde",
- "serde_derive",
- "serde_json",
- "unicode-xid",
- "wasmparser",
-]
 
 [[package]]
 name = "writeable"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -616,7 +616,7 @@ dependencies = [
 [[package]]
 name = "fastga-rs"
 version = "0.1.2"
-source = "git+https://github.com/pangenome/fastga-rs?rev=e5037d5#e5037d5ef818f0ed1eef68e5678324a3b6f9111a"
+source = "git+https://github.com/pangenome/fastga-rs?rev=eb50026#eb50026cae4d7b114dfa2466e35bf13e41c94a52"
 dependencies = [
  "anyhow",
  "cc",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -30,7 +30,7 @@ rayon = "1.10"
 byteorder = "1.5"
 tempfile = "3.8"
 ordered-float = "4.0"
-fastga-rs = { git = "https://github.com/pangenome/fastga-rs", rev = "eb50026" }
+fastga-rs = { git = "https://github.com/pangenome/fastga-rs", rev = "2da9567" }
 wfmash-rs = { git = "https://github.com/pangenome/wfmash-rs", rev = "3cc667743d59eca4f9fae0ea3fa9d4ee8b5a3ad6" }
 rust-htslib = { version = "1.0.0", default-features = false, features = ["libdeflate"] }
 ragc-core = { git = "https://github.com/ekg/ragc", rev = "40e5cad11cab7d4df07a72d6b16d68c2d60b0742" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -31,7 +31,7 @@ byteorder = "1.5"
 tempfile = "3.8"
 ordered-float = "4.0"
 fastga-rs = { git = "https://github.com/pangenome/fastga-rs", rev = "e5037d5" }
-wfmash-rs = { git = "https://github.com/pangenome/wfmash-rs", rev = "d47b7e3e" }
+wfmash-rs = { git = "https://github.com/pangenome/wfmash-rs", rev = "3cc667743d59eca4f9fae0ea3fa9d4ee8b5a3ad6" }
 rust-htslib = { version = "1.0.0", default-features = false, features = ["libdeflate"] }
 ragc-core = { git = "https://github.com/ekg/ragc", rev = "40e5cad11cab7d4df07a72d6b16d68c2d60b0742" }
 onecode = { git = "https://github.com/pangenome/onecode-rs", rev = "f531f5b0ff54001a898ec4e0c0c761b2bd0a1f34" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -30,7 +30,7 @@ rayon = "1.10"
 byteorder = "1.5"
 tempfile = "3.8"
 ordered-float = "4.0"
-fastga-rs = { git = "https://github.com/pangenome/fastga-rs", rev = "e5037d5" }
+fastga-rs = { git = "https://github.com/pangenome/fastga-rs", rev = "eb50026" }
 wfmash-rs = { git = "https://github.com/pangenome/wfmash-rs", rev = "3cc667743d59eca4f9fae0ea3fa9d4ee8b5a3ad6" }
 rust-htslib = { version = "1.0.0", default-features = false, features = ["libdeflate"] }
 ragc-core = { git = "https://github.com/ekg/ragc", rev = "40e5cad11cab7d4df07a72d6b16d68c2d60b0742" }

--- a/src/batch_align.rs
+++ b/src/batch_align.rs
@@ -184,6 +184,11 @@ pub struct WfmashBatchAligner {
     /// Mapping density (wfmash `-x`). Forwarded verbatim to every per-batch
     /// `WfmashIntegration`. `None` (or `Some(1.0)`) keeps all mappings.
     sparsify: Option<f64>,
+    /// Pair-level sparsification: when `Some`, restrict alignment to the
+    /// `query\ttarget` pairs listed in the TSV. Applied via wfmash's
+    /// `--pairs-file` within each per-batch wfmash invocation — so
+    /// batching and pair sparsification compose correctly.
+    pairs_file: Option<PathBuf>,
 }
 
 impl WfmashBatchAligner {
@@ -193,6 +198,7 @@ impl WfmashBatchAligner {
         map_pct_identity: Option<String>,
         temp_dir: Option<String>,
         sparsify: Option<f64>,
+        pairs_file: Option<PathBuf>,
     ) -> Self {
         Self {
             num_threads,
@@ -200,6 +206,7 @@ impl WfmashBatchAligner {
             map_pct_identity,
             temp_dir,
             sparsify,
+            pairs_file,
         }
     }
 
@@ -215,7 +222,7 @@ impl WfmashBatchAligner {
             avg_seq,
             self.sparsify,
             None, // num_mappings
-            None, // pairs_file
+            self.pairs_file.clone(),
         )
     }
 }

--- a/src/binary_paths.rs
+++ b/src/binary_paths.rs
@@ -3,7 +3,8 @@
 //! Search order:
 //! 1. ~/.cache/sweepga/{cache_key}/  (installed by build.rs)
 //! 2. target/{profile}/build/{dep}-*/out/  (development fallback)
-//! 3. PATH  (system fallback)
+//! 3. <exe_dir>/../libexec/<exe_stem>/  (packaged installs, e.g. conda)
+//! 4. PATH  (system fallback)
 
 use anyhow::{anyhow, Result};
 use std::env;
@@ -44,7 +45,15 @@ pub fn get_embedded_binary_path(binary_name: &str) -> Result<PathBuf> {
         return Ok(path);
     }
 
-    // 3. System PATH
+    // 3. Private install directory (packaged installs, e.g. conda)
+    if let Some(dir) = libexec_dir() {
+        let p = dir.join(binary_name);
+        if p.exists() {
+            return Ok(p);
+        }
+    }
+
+    // 4. System PATH
     if let Ok(output) = std::process::Command::new("which")
         .arg(binary_name)
         .output()
@@ -59,9 +68,28 @@ pub fn get_embedded_binary_path(binary_name: &str) -> Result<PathBuf> {
 
     Err(anyhow!(
         "Binary '{binary_name}' not found.\n\
-         Searched: cache (~/.cache/sweepga/), build tree, PATH.\n\
+         Searched: cache (~/.cache/sweepga/), build tree, libexec, PATH.\n\
          Try running 'cargo build --release' first."
     ))
+}
+
+/// Private install directory next to the running executable:
+/// `<exe_dir>/../libexec/<exe_stem>/`.
+///
+/// Package managers use this to keep bundled wfmash and FastGA binaries out of
+/// `bin/`, where they would overwrite the separately packaged versions.
+pub fn libexec_dir() -> Option<PathBuf> {
+    let exe = env::current_exe().ok()?;
+    let dir = exe
+        .parent()?
+        .parent()?
+        .join("libexec")
+        .join(exe.file_stem()?);
+    if dir.is_dir() {
+        Some(dir)
+    } else {
+        None
+    }
 }
 
 /// Prepend the binary cache/build directory to PATH and set WFMASH_BIN_DIR.

--- a/src/joblist.rs
+++ b/src/joblist.rs
@@ -73,6 +73,68 @@ pub fn write_pair_commands<W: Write>(
     Ok(())
 }
 
+/// Configuration for emitting a wfmash-per-haplotype-pair joblist.
+///
+/// Targets the "one PanSN-named FASTA in, one wfmash invocation per
+/// selected `SAMPLE#HAPLOTYPE` pair out" flow: wfmash filters queries and
+/// targets to those haplotype prefixes via `-Q` / `-T`, aligning only the
+/// contigs that match, without the user having to pre-split the input
+/// into per-haplotype FASTAs.
+pub struct WfmashPansnEmitConfig<'a> {
+    /// Path to the PanSN-named FASTA input (used for both query and
+    /// target sides of each wfmash invocation).
+    pub fasta: &'a Path,
+    /// Output directory for per-pair PAFs.
+    pub output_dir: &'a Path,
+    /// Number of threads to pass via `-t`.
+    pub threads: usize,
+    /// Optional block-length filter (`-l`). 0 means "omit the flag".
+    pub block_length: u64,
+}
+
+/// Replace filesystem-hostile characters (notably PanSN's `#`) so a
+/// `SAMPLE#HAPLOTYPE` key is safe to embed in a filename.
+fn sanitize_for_filename(s: &str) -> String {
+    s.chars()
+        .map(|c| match c {
+            '/' | '\\' | '#' | ':' | ' ' | '\t' | '*' | '?' | '"' | '<' | '>' | '|' => '_',
+            other => other,
+        })
+        .collect()
+}
+
+/// Emit one `wfmash -T <target_hap> -Q <query_hap>` command per PanSN
+/// haplotype pair.
+///
+/// `hap_pairs` are `(target_haplotype_key, query_haplotype_key)` string
+/// tuples — e.g. `("HG01106#1", "HG00733#2")`. The output filename for
+/// each pair is `<output_dir>/<target>_vs_<query>.paf`, with `#` replaced
+/// by `_`. When `block_length` is non-zero the emitted command includes
+/// `-l <block_length>`; this is the only filtering flag that wfmash's
+/// `-T`/`-Q` workflow honors.
+pub fn write_wfmash_pansn_commands<W: Write>(
+    hap_pairs: &[(String, String)],
+    cfg: &WfmashPansnEmitConfig,
+    writer: &mut W,
+) -> Result<()> {
+    for (target_hap, query_hap) in hap_pairs {
+        let output = cfg.output_dir.join(format!(
+            "{}_vs_{}.paf",
+            sanitize_for_filename(target_hap),
+            sanitize_for_filename(query_hap),
+        ));
+        let mut cmd = format!("wfmash -t {}", cfg.threads);
+        if cfg.block_length > 0 {
+            cmd.push_str(&format!(" -l {}", cfg.block_length));
+        }
+        cmd.push_str(&format!(" -T {} -Q {}", target_hap, query_hap));
+        cmd.push_str(&format!(" {}", cfg.fasta.display()));
+        cmd.push_str(&format!(" > {}", output.display()));
+        writeln!(writer, "{}", cmd)?;
+    }
+    Ok(())
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -115,5 +177,48 @@ mod tests {
         let mut buf = Vec::new();
         write_pair_commands(&[], &cfg, &mut buf).unwrap();
         assert!(buf.is_empty());
+    }
+
+    #[test]
+    fn wfmash_pansn_emits_T_Q_per_hap_pair() {
+        let pairs = vec![
+            ("HG01106#1".to_string(), "HG00733#2".to_string()),
+            ("SGDref#0".to_string(), "HG01106#1".to_string()),
+        ];
+        let cfg = WfmashPansnEmitConfig {
+            fasta: Path::new("/data/pangenome.fa"),
+            output_dir: Path::new("/out"),
+            threads: 8,
+            block_length: 0,
+        };
+        let mut buf = Vec::new();
+        write_wfmash_pansn_commands(&pairs, &cfg, &mut buf).unwrap();
+        let s = String::from_utf8(buf).unwrap();
+        let lines: Vec<&str> = s.lines().collect();
+        assert_eq!(lines.len(), 2);
+        assert_eq!(
+            lines[0],
+            "wfmash -t 8 -T HG01106#1 -Q HG00733#2 /data/pangenome.fa > /out/HG01106_1_vs_HG00733_2.paf"
+        );
+        assert_eq!(
+            lines[1],
+            "wfmash -t 8 -T SGDref#0 -Q HG01106#1 /data/pangenome.fa > /out/SGDref_0_vs_HG01106_1.paf"
+        );
+    }
+
+    #[test]
+    fn wfmash_pansn_includes_block_length_when_set() {
+        let pairs = vec![("A#0".to_string(), "B#0".to_string())];
+        let cfg = WfmashPansnEmitConfig {
+            fasta: Path::new("pg.fa"),
+            output_dir: Path::new("."),
+            threads: 4,
+            block_length: 20_000,
+        };
+        let mut buf = Vec::new();
+        write_wfmash_pansn_commands(&pairs, &cfg, &mut buf).unwrap();
+        let s = String::from_utf8(buf).unwrap();
+        assert!(s.contains("-l 20000"));
+        assert!(s.contains("-T A#0 -Q B#0"));
     }
 }

--- a/src/joblist.rs
+++ b/src/joblist.rs
@@ -73,17 +73,22 @@ pub fn write_pair_commands<W: Write>(
     Ok(())
 }
 
-/// Configuration for emitting a wfmash-per-haplotype-pair joblist.
+/// One PanSN haplotype-pair wfmash job: the `(target_hap, query_hap)`
+/// keys and the target / query FASTA paths the command should run on.
 ///
-/// Targets the "one PanSN-named FASTA in, one wfmash invocation per
-/// selected `SAMPLE#HAPLOTYPE` pair out" flow: wfmash filters queries and
-/// targets to those haplotype prefixes via `-Q` / `-T`, aligning only the
-/// contigs that match, without the user having to pre-split the input
-/// into per-haplotype FASTAs.
+/// Single-file callers set `target_fasta == query_fasta`; multi-file
+/// callers point each side at whichever FASTA contains the relevant
+/// haplotype's contigs. When the two paths are equal the emitted command
+/// omits the query file (wfmash self-map form).
+pub struct WfmashPansnJob {
+    pub target_hap: String,
+    pub query_hap: String,
+    pub target_fasta: std::path::PathBuf,
+    pub query_fasta: std::path::PathBuf,
+}
+
+/// Shared emission config for [`write_wfmash_pansn_commands`].
 pub struct WfmashPansnEmitConfig<'a> {
-    /// Path to the PanSN-named FASTA input (used for both query and
-    /// target sides of each wfmash invocation).
-    pub fasta: &'a Path,
     /// Output directory for per-pair PAFs.
     pub output_dir: &'a Path,
     /// Number of threads to pass via `-t`.
@@ -103,32 +108,37 @@ fn sanitize_for_filename(s: &str) -> String {
         .collect()
 }
 
-/// Emit one `wfmash -T <target_hap> -Q <query_hap>` command per PanSN
-/// haplotype pair.
+/// Emit one `wfmash -T <target_hap> -Q <query_hap> target.fa [query.fa]`
+/// command per PanSN haplotype-pair job.
 ///
-/// `hap_pairs` are `(target_haplotype_key, query_haplotype_key)` string
-/// tuples — e.g. `("HG01106#1", "HG00733#2")`. The output filename for
-/// each pair is `<output_dir>/<target>_vs_<query>.paf`, with `#` replaced
-/// by `_`. When `block_length` is non-zero the emitted command includes
-/// `-l <block_length>`; this is the only filtering flag that wfmash's
-/// `-T`/`-Q` workflow honors.
+/// Works for both single-FASTA PanSN inputs (each job's target and query
+/// FASTA are the same physical file; wfmash self-maps with `-T`/`-Q`
+/// filtering) and multi-FASTA PanSN inputs (jobs point at whichever
+/// FASTA holds the haplotype's contigs; the second file is passed
+/// through when it differs from the first).
+///
+/// Output filename is `<output_dir>/<target>_vs_<query>.paf`, with
+/// PanSN `#` replaced by `_` for filesystem safety.
 pub fn write_wfmash_pansn_commands<W: Write>(
-    hap_pairs: &[(String, String)],
+    jobs: &[WfmashPansnJob],
     cfg: &WfmashPansnEmitConfig,
     writer: &mut W,
 ) -> Result<()> {
-    for (target_hap, query_hap) in hap_pairs {
+    for job in jobs {
         let output = cfg.output_dir.join(format!(
             "{}_vs_{}.paf",
-            sanitize_for_filename(target_hap),
-            sanitize_for_filename(query_hap),
+            sanitize_for_filename(&job.target_hap),
+            sanitize_for_filename(&job.query_hap),
         ));
         let mut cmd = format!("wfmash -t {}", cfg.threads);
         if cfg.block_length > 0 {
             cmd.push_str(&format!(" -l {}", cfg.block_length));
         }
-        cmd.push_str(&format!(" -T {} -Q {}", target_hap, query_hap));
-        cmd.push_str(&format!(" {}", cfg.fasta.display()));
+        cmd.push_str(&format!(" -T {} -Q {}", job.target_hap, job.query_hap));
+        cmd.push_str(&format!(" {}", job.target_fasta.display()));
+        if job.query_fasta != job.target_fasta {
+            cmd.push_str(&format!(" {}", job.query_fasta.display()));
+        }
         cmd.push_str(&format!(" > {}", output.display()));
         writeln!(writer, "{}", cmd)?;
     }
@@ -179,20 +189,29 @@ mod tests {
         assert!(buf.is_empty());
     }
 
+    fn pj(tgt: &str, qry: &str, tgt_fa: &str, qry_fa: &str) -> WfmashPansnJob {
+        WfmashPansnJob {
+            target_hap: tgt.to_string(),
+            query_hap: qry.to_string(),
+            target_fasta: std::path::PathBuf::from(tgt_fa),
+            query_fasta: std::path::PathBuf::from(qry_fa),
+        }
+    }
+
     #[test]
-    fn wfmash_pansn_emits_T_Q_per_hap_pair() {
-        let pairs = vec![
-            ("HG01106#1".to_string(), "HG00733#2".to_string()),
-            ("SGDref#0".to_string(), "HG01106#1".to_string()),
+    fn wfmash_pansn_emits_T_Q_per_hap_pair_single_fasta() {
+        // Same file on both sides → emit with self-map form (one file arg).
+        let jobs = vec![
+            pj("HG01106#1", "HG00733#2", "/data/pangenome.fa", "/data/pangenome.fa"),
+            pj("SGDref#0", "HG01106#1", "/data/pangenome.fa", "/data/pangenome.fa"),
         ];
         let cfg = WfmashPansnEmitConfig {
-            fasta: Path::new("/data/pangenome.fa"),
             output_dir: Path::new("/out"),
             threads: 8,
             block_length: 0,
         };
         let mut buf = Vec::new();
-        write_wfmash_pansn_commands(&pairs, &cfg, &mut buf).unwrap();
+        write_wfmash_pansn_commands(&jobs, &cfg, &mut buf).unwrap();
         let s = String::from_utf8(buf).unwrap();
         let lines: Vec<&str> = s.lines().collect();
         assert_eq!(lines.len(), 2);
@@ -207,16 +226,34 @@ mod tests {
     }
 
     #[test]
-    fn wfmash_pansn_includes_block_length_when_set() {
-        let pairs = vec![("A#0".to_string(), "B#0".to_string())];
+    fn wfmash_pansn_emits_both_files_when_distinct() {
+        // Different files on each side → emit both, in wfmash order
+        // (target.fa query.fa).
+        let jobs = vec![pj("HG01106#1", "HG00733#2", "/data/hg01106.fa", "/data/hg00733.fa")];
         let cfg = WfmashPansnEmitConfig {
-            fasta: Path::new("pg.fa"),
+            output_dir: Path::new("/out"),
+            threads: 4,
+            block_length: 0,
+        };
+        let mut buf = Vec::new();
+        write_wfmash_pansn_commands(&jobs, &cfg, &mut buf).unwrap();
+        let s = String::from_utf8(buf).unwrap();
+        assert_eq!(
+            s.trim_end(),
+            "wfmash -t 4 -T HG01106#1 -Q HG00733#2 /data/hg01106.fa /data/hg00733.fa > /out/HG01106_1_vs_HG00733_2.paf"
+        );
+    }
+
+    #[test]
+    fn wfmash_pansn_includes_block_length_when_set() {
+        let jobs = vec![pj("A#0", "B#0", "pg.fa", "pg.fa")];
+        let cfg = WfmashPansnEmitConfig {
             output_dir: Path::new("."),
             threads: 4,
             block_length: 20_000,
         };
         let mut buf = Vec::new();
-        write_wfmash_pansn_commands(&pairs, &cfg, &mut buf).unwrap();
+        write_wfmash_pansn_commands(&jobs, &cfg, &mut buf).unwrap();
         let s = String::from_utf8(buf).unwrap();
         assert!(s.contains("-l 20000"));
         assert!(s.contains("-T A#0 -Q B#0"));

--- a/src/knn_graph.rs
+++ b/src/knn_graph.rs
@@ -559,6 +559,124 @@ pub fn select_pairs_from_sketches(
     }
 }
 
+/// Merge MinHash sketches by unioning their minimizer vectors and
+/// re-truncating to `sketch_size`. MinHash bottom-k has the mergeability
+/// property that the bottom-k of the union equals the bottom-k of the
+/// merged bottom-k sketches — so this produces exactly the sketch we
+/// would have gotten had we computed it over the concatenated sequence,
+/// without re-hashing.
+pub fn merge_sketches(
+    parts: &[&mash::KmerSketch],
+    sketch_size: usize,
+) -> mash::KmerSketch {
+    let k = parts.first().map(|s| s.k).unwrap_or(mash::DEFAULT_KMER_SIZE);
+    let mut minimizers: Vec<u64> = parts
+        .iter()
+        .flat_map(|s| s.minimizers.iter().copied())
+        .collect();
+    let length: usize = parts.iter().map(|s| s.length).sum();
+    minimizers.sort_unstable();
+    minimizers.dedup();
+    minimizers.truncate(sketch_size);
+    mash::KmerSketch { minimizers, k, length }
+}
+
+/// Expand PanSN haplotype-level pairs into contig-level pairs:
+/// the cross-product of contigs across selected haplotype pairs, plus every
+/// intra-haplotype contig pair (same-sample contigs — always kept together).
+///
+/// Output pairs are normalized `(min, max)` and deduplicated.
+pub fn expand_haplotype_pairs(
+    hap_pairs: &[(usize, usize)],
+    hap_groups: &[Vec<usize>],
+) -> Vec<(usize, usize)> {
+    use std::collections::HashSet;
+    let mut seen: HashSet<(usize, usize)> = HashSet::new();
+    for &(hi, hj) in hap_pairs {
+        for &ci in &hap_groups[hi] {
+            for &cj in &hap_groups[hj] {
+                if ci == cj {
+                    continue;
+                }
+                let pair = if ci < cj { (ci, cj) } else { (cj, ci) };
+                seen.insert(pair);
+            }
+        }
+    }
+    for contigs in hap_groups {
+        for a in 0..contigs.len() {
+            for b in a + 1..contigs.len() {
+                let (ci, cj) = (contigs[a], contigs[b]);
+                let pair = if ci < cj { (ci, cj) } else { (cj, ci) };
+                seen.insert(pair);
+            }
+        }
+    }
+    let mut out: Vec<(usize, usize)> = seen.into_iter().collect();
+    out.sort_unstable();
+    out
+}
+
+/// Sparsify at PanSN haplotype granularity, then project back to contig
+/// pairs.
+///
+/// For pangenome inputs where "sample#haplotype#contig" names pack multiple
+/// contigs per haplotype, running `select_pairs_from_sketches` directly at
+/// the contig level loses biological structure — a random fraction of
+/// contig pairs gives an uneven sample across haplotypes. This helper
+/// groups contigs by haplotype, merges their MinHash sketches into one
+/// per-haplotype sketch, runs the strategy on the haplotype graph, and
+/// then expands each selected haplotype pair to the full cross-product of
+/// contig pairs (plus all intra-haplotype contig pairs, which are
+/// free-to-keep).
+///
+/// Falls back to plain contig-level `select_pairs_from_sketches` when the
+/// input isn't PanSN-named (detected as: the number of distinct haplotype
+/// groups equals the number of input contigs).
+pub fn select_pairs_haplotype_aware(
+    names: &[&str],
+    contig_sketches: &[mash::KmerSketch],
+    strategy: &SparsificationStrategy,
+    sketch_size: usize,
+) -> Vec<(usize, usize)> {
+    use crate::pansn::{group_indices_by_pansn, PanSnLevel};
+    let hap_groups = group_indices_by_pansn(names.iter().copied(), PanSnLevel::Haplotype);
+    if hap_groups.len() == contig_sketches.len() {
+        return select_pairs_from_sketches(contig_sketches, strategy);
+    }
+    let hap_sketches: Vec<mash::KmerSketch> = hap_groups
+        .iter()
+        .map(|idxs| {
+            let parts: Vec<&mash::KmerSketch> =
+                idxs.iter().map(|&i| &contig_sketches[i]).collect();
+            merge_sketches(&parts, sketch_size)
+        })
+        .collect();
+    let hap_pairs = select_pairs_from_sketches(&hap_sketches, strategy);
+    expand_haplotype_pairs(&hap_pairs, &hap_groups)
+}
+
+/// Sketch-free variant of [`select_pairs_haplotype_aware`] for the
+/// `None` / `Random(_)` / `WfmashDensity(_)` strategies that don't
+/// need per-node distances. The strategy is applied at the haplotype level
+/// — so `Random(0.05)` samples 5% of *haplotype pairs* (and then expands
+/// each to contig pairs), which matches the biologically-meaningful unit
+/// rather than the per-contig pair count that can be wildly uneven.
+pub fn select_pairs_haplotype_aware_no_sketch(
+    names: &[&str],
+    strategy: &SparsificationStrategy,
+    mash_params: &MashParams,
+) -> Vec<(usize, usize)> {
+    use crate::pansn::{group_indices_by_pansn, PanSnLevel};
+    let n = names.len();
+    let hap_groups = group_indices_by_pansn(names.iter().copied(), PanSnLevel::Haplotype);
+    if hap_groups.len() == n {
+        return select_pairs(n, None, strategy, mash_params);
+    }
+    let hap_pairs = select_pairs(hap_groups.len(), None, strategy, mash_params);
+    expand_haplotype_pairs(&hap_pairs, &hap_groups)
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -613,6 +731,64 @@ mod tests {
     fn test_select_pairs_none() {
         let pairs = select_pairs(4, None, &SparsificationStrategy::None, &MashParams::default());
         assert_eq!(pairs.len(), 6); // 4 choose 2 = 6
+    }
+
+    #[test]
+    fn test_merge_sketches_is_bottom_k_union() {
+        let a = mash::KmerSketch::from_sequence(b"ACGTACGTACGTACGT", 5, 100);
+        let b = mash::KmerSketch::from_sequence(b"TTTTGGGGAAAACCCC", 5, 100);
+        let merged = merge_sketches(&[&a, &b], 100);
+        assert_eq!(merged.k, 5);
+        assert_eq!(merged.length, a.length + b.length);
+        // Every merged minimizer must come from one of the parts
+        let union: std::collections::HashSet<u64> =
+            a.minimizers.iter().chain(b.minimizers.iter()).copied().collect();
+        for m in &merged.minimizers {
+            assert!(union.contains(m));
+        }
+        // Sketch is sorted & deduped
+        for w in merged.minimizers.windows(2) {
+            assert!(w[0] < w[1]);
+        }
+    }
+
+    #[test]
+    fn test_expand_haplotype_pairs_cross_and_intra() {
+        // hap_0 = indices [0,1], hap_1 = [2,3,4]
+        let groups = vec![vec![0, 1], vec![2, 3, 4]];
+        let pairs = expand_haplotype_pairs(&[(0, 1)], &groups);
+        // 2*3 cross + 1 intra(hap0) + 3 intra(hap1) = 10 pairs
+        assert_eq!(pairs.len(), 10);
+        assert!(pairs.contains(&(0, 1))); // intra hap_0
+        assert!(pairs.contains(&(2, 3))); // intra hap_1
+        assert!(pairs.contains(&(0, 2))); // cross
+        assert!(pairs.contains(&(1, 4))); // cross
+    }
+
+    #[test]
+    fn test_haplotype_aware_none_strategy_matches_all_pairs() {
+        // 4 contigs across 2 haplotypes; None strategy at hap level expands
+        // to all 6 contig pairs.
+        let names = ["S1#1#a", "S1#1#b", "S2#1#a", "S2#1#b"];
+        let pairs = select_pairs_haplotype_aware_no_sketch(
+            &names,
+            &SparsificationStrategy::None,
+            &MashParams::default(),
+        );
+        assert_eq!(pairs.len(), 6);
+    }
+
+    #[test]
+    fn test_haplotype_aware_non_pansn_falls_back_to_contig() {
+        // Non-PanSN names: every name is its own haplotype, so behavior must
+        // be identical to direct contig-level selection.
+        let names = ["chr1", "chr2", "chr3"];
+        let pairs = select_pairs_haplotype_aware_no_sketch(
+            &names,
+            &SparsificationStrategy::None,
+            &MashParams::default(),
+        );
+        assert_eq!(pairs.len(), 3); // 3 choose 2
     }
 
     #[test]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -30,7 +30,7 @@ pub mod wfmash_integration;
 pub use cli::{parse_identity_value, parse_metric_number, AlnArgs};
 
 use anyhow::Result;
-use std::path::Path;
+use std::path::{Path, PathBuf};
 
 /// Direct (non-batched) self-alignment: hands `fasta_path` to the
 /// already-constructed `aligner` and returns its raw PAF temp file.
@@ -44,6 +44,13 @@ pub fn align_self_paf_direct(
 /// Batched self-alignment: partitions genomes within `fasta_path` into
 /// batches sized by `batch_bytes` (e.g. `"2G"`) and aligns each batch
 /// pair, limiting per-batch resource usage.
+///
+/// `pairs_file`: optional path to a `query\ttarget` TSV (as produced by
+/// pair-level sparsification upstream). When set AND the aligner is
+/// `wfmash`, every per-batch wfmash invocation uses `--pairs-file` to
+/// restrict to those pairs — so batching and pair sparsification
+/// compose correctly. Ignored for FastGA (which doesn't support
+/// pair-file filtering).
 pub fn align_self_paf_batched(
     fasta_path: &Path,
     aligner_name: &str,
@@ -53,6 +60,7 @@ pub fn align_self_paf_batched(
     map_pct_identity: Option<String>,
     temp_dir: Option<String>,
     wfmash_density: Option<f64>,
+    pairs_file: Option<PathBuf>,
     batch_bytes: &str,
     quiet: bool,
 ) -> Result<tempfile::NamedTempFile> {
@@ -66,6 +74,7 @@ pub fn align_self_paf_batched(
             map_pct_identity,
             temp_dir.clone(),
             wfmash_density,
+            pairs_file,
         )),
         _ => Box::new(batch_align::FastGABatchAligner::new(
             kmer_frequency,

--- a/src/library_api.rs
+++ b/src/library_api.rs
@@ -392,6 +392,7 @@ fn sweepga_align_all_vs_all(
             config.map_pct_identity.clone(),
             config.temp_dir.clone(),
             wfmash_density,
+            None, // pairs_file: all-vs-all path doesn't use pair selection
             batch_bytes,
             true, // quiet
         ),

--- a/src/main.rs
+++ b/src/main.rs
@@ -787,6 +787,173 @@ fn extract_genome_prefix(seq_name: &str) -> Option<String> {
     }
 }
 
+/// Read sequence names and lengths from a FASTA file (bgzf or plain).
+fn read_fasta_names_and_lengths(fasta_path: &Path) -> Result<(Vec<String>, Vec<usize>)> {
+    use std::io::{BufRead, BufReader};
+    let file = File::open(fasta_path)
+        .with_context(|| format!("Failed to open FASTA '{}'", fasta_path.display()))?;
+    let reader: Box<dyn BufRead> = if fasta_path.to_string_lossy().ends_with(".gz") {
+        Box::new(BufReader::new(noodles::bgzf::io::reader::Reader::new(file)))
+    } else {
+        Box::new(BufReader::new(file))
+    };
+    let mut names = Vec::new();
+    let mut lengths = Vec::new();
+    let mut cur_len: usize = 0;
+    let mut have_current = false;
+    for line in reader.lines() {
+        let line = line?;
+        if let Some(stripped) = line.strip_prefix('>') {
+            if have_current {
+                lengths.push(cur_len);
+            }
+            names.push(
+                stripped
+                    .split_whitespace()
+                    .next()
+                    .unwrap_or("")
+                    .to_string(),
+            );
+            cur_len = 0;
+            have_current = true;
+        } else {
+            cur_len += line.trim().len();
+        }
+    }
+    if have_current {
+        lengths.push(cur_len);
+    }
+    Ok((names, lengths))
+}
+
+/// For a single PanSN-named FASTA, return the sparsified list of
+/// `(target_haplotype, query_haplotype)` key pairs that `--joblist` should
+/// emit wfmash commands for.
+///
+/// Every haplotype is also emitted as a self-pair `(hap, hap)` so the
+/// downstream aligner runs intra-haplotype too (wfmash's default group-
+/// prefix behavior skips those internally; including them keeps the
+/// joblist semantically explicit and harmless).
+fn pansn_joblist_hap_pairs(
+    fasta: &Path,
+    aln: &AlnArgs,
+) -> Result<Vec<(String, String)>> {
+    use crate::pansn::{group_indices_by_pansn, PanSnLevel};
+    let (names, _lengths) = read_fasta_names_and_lengths(fasta)?;
+    let name_refs: Vec<&str> = names.iter().map(|s| s.as_str()).collect();
+    let hap_groups = group_indices_by_pansn(name_refs.iter().copied(), PanSnLevel::Haplotype);
+    let hap_keys: Vec<String> = hap_groups
+        .iter()
+        .filter_map(|g| {
+            g.first().and_then(|&i| {
+                crate::pansn::extract_pansn_key(&names[i], PanSnLevel::Haplotype)
+                    .or_else(|| Some(names[i].clone()))
+            })
+        })
+        .collect();
+    if hap_keys.is_empty() {
+        anyhow::bail!("No sequences detected in {}", fasta.display());
+    }
+
+    // Build contig-level sketches only when the strategy actually needs
+    // distances. Sketch-free strategies (None / Random / WfmashDensity) use
+    // the no-sketch fast path.
+    let mash_params = knn_graph::MashParams {
+        kmer_size: aln.mash_kmer_size,
+        sketch_size: aln.mash_sketch_size,
+    };
+
+    let contig_pair_indices: Vec<(usize, usize)> = match &aln.sparsify {
+        knn_graph::SparsificationStrategy::None
+        | knn_graph::SparsificationStrategy::Random(_)
+        | knn_graph::SparsificationStrategy::WfmashDensity(_) => {
+            knn_graph::select_pairs_haplotype_aware_no_sketch(
+                &name_refs,
+                &aln.sparsify,
+                &mash_params,
+            )
+        }
+        _ => {
+            // Sketch-based strategies need per-contig sequences; read them
+            // in one pass.
+            let sequences = read_fasta_sequences_for_sketching(fasta)?;
+            let seq_bytes: Vec<&[u8]> = sequences.iter().map(|s| s.as_slice()).collect();
+            let sketches = mash::compute_sketches_parallel(
+                &sequences,
+                mash_params.kmer_size,
+                mash_params.sketch_size,
+            );
+            let _ = seq_bytes;
+            knn_graph::select_pairs_haplotype_aware(
+                &name_refs,
+                &sketches,
+                &aln.sparsify,
+                mash_params.sketch_size,
+            )
+        }
+    };
+
+    // Collapse contig-pair output back to haplotype keys. expand_haplotype_pairs
+    // emits every contig pair including intra-haplotype; the user of the
+    // wfmash-per-hap joblist only wants unique haplotype-pair keys.
+    // Per-contig → per-hap key.
+    let hap_of: Vec<String> = name_refs
+        .iter()
+        .map(|n| {
+            crate::pansn::extract_pansn_key(n, PanSnLevel::Haplotype)
+                .unwrap_or_else(|| (*n).to_string())
+        })
+        .collect();
+    let mut seen: std::collections::BTreeSet<(String, String)> =
+        std::collections::BTreeSet::new();
+    for (i, j) in contig_pair_indices {
+        let (a, b) = (&hap_of[i], &hap_of[j]);
+        let pair = if a <= b {
+            (a.clone(), b.clone())
+        } else {
+            (b.clone(), a.clone())
+        };
+        seen.insert(pair);
+    }
+    // Always include each haplotype as a self-pair so intra-haplotype
+    // alignments are represented explicitly in the joblist.
+    for k in &hap_keys {
+        seen.insert((k.clone(), k.clone()));
+    }
+    Ok(seen.into_iter().collect())
+}
+
+/// Read FASTA sequences (plain / bgzf) into a `Vec<Vec<u8>>` (one per
+/// record, in file order). Used for sketch-based joblist sparsification.
+fn read_fasta_sequences_for_sketching(fasta_path: &Path) -> Result<Vec<Vec<u8>>> {
+    use std::io::{BufRead, BufReader};
+    let file = File::open(fasta_path)
+        .with_context(|| format!("Failed to open FASTA '{}'", fasta_path.display()))?;
+    let reader: Box<dyn BufRead> = if fasta_path.to_string_lossy().ends_with(".gz") {
+        Box::new(BufReader::new(noodles::bgzf::io::reader::Reader::new(file)))
+    } else {
+        Box::new(BufReader::new(file))
+    };
+    let mut out: Vec<Vec<u8>> = Vec::new();
+    let mut cur: Vec<u8> = Vec::new();
+    let mut have_current = false;
+    for line in reader.lines() {
+        let line = line?;
+        if line.starts_with('>') {
+            if have_current {
+                out.push(std::mem::take(&mut cur));
+            }
+            have_current = true;
+        } else {
+            cur.extend_from_slice(line.trim().as_bytes());
+        }
+    }
+    if have_current {
+        out.push(cur);
+    }
+    Ok(out)
+}
+
 /// Detect genome groups from a FASTA file by reading headers
 fn detect_genome_groups(fasta_path: &Path) -> Result<Vec<String>> {
     use std::collections::BTreeSet;
@@ -2493,40 +2660,65 @@ fn main() -> Result<()> {
         vec![]
     };
 
-    // --joblist: emit one shell command per FASTA pair and exit. The
-    // emitted commands are standalone `sweepga` invocations, one per
-    // unordered pair (i,j) with i<j. Sparsify strategies are not yet
-    // applied here — a future revision can enumerate the sparsified pair
-    // set and reuse the same helper.
+    // --joblist: emit one shell command per pair and exit. Two modes:
+    //
+    //   * Multi-FASTA input: emit a standalone `sweepga` invocation per
+    //     unordered file pair `(i,j)`. The existing flow.
+    //   * Single PanSN-named FASTA: group contigs by `SAMPLE#HAPLOTYPE`,
+    //     sparsify at haplotype granularity, and emit one
+    //     `wfmash -T <hap_i> -Q <hap_j>` command per selected pair. The
+    //     emitted commands reuse the single input file on both sides;
+    //     wfmash filters to the relevant contigs via its prefix flags.
     if args.aln.joblist {
-        if args.files.len() < 2 {
-            anyhow::bail!("--joblist requires at least 2 FASTA inputs");
+        if args.files.is_empty() {
+            anyhow::bail!("--joblist requires FASTA input");
         }
         if input_file_types.iter().any(|ft| *ft != FileType::Fasta) {
             anyhow::bail!("--joblist requires FASTA inputs (got non-FASTA file)");
-        }
-        let mut pairs: Vec<(String, String)> = Vec::new();
-        for i in 0..args.files.len() {
-            for j in (i + 1)..args.files.len() {
-                pairs.push((args.files[i].clone(), args.files[j].clone()));
-            }
         }
         let out_dir = args
             .aln
             .joblist_output_dir
             .clone()
             .unwrap_or_else(|| ".".to_string());
+        let out_dir_path = Path::new(&out_dir);
+        std::fs::create_dir_all(out_dir_path).with_context(|| {
+            format!("Failed to create joblist output dir '{}'", out_dir)
+        })?;
+
+        let mut out: Box<dyn std::io::Write> = match &args.output_file {
+            Some(f) => Box::new(std::fs::File::create(f)?),
+            None => Box::new(std::io::stdout()),
+        };
+
+        if args.files.len() == 1 {
+            // Single-FASTA PanSN path: emit wfmash -T -Q per haplotype pair.
+            let fasta = Path::new(&args.files[0]);
+            let hap_pairs = pansn_joblist_hap_pairs(fasta, &args.aln)?;
+            let cfg = joblist::WfmashPansnEmitConfig {
+                fasta,
+                output_dir: out_dir_path,
+                threads: args.threads,
+                block_length: args.aln.block_length.unwrap_or(0),
+            };
+            joblist::write_wfmash_pansn_commands(&hap_pairs, &cfg, &mut out)?;
+            return Ok(());
+        }
+
+        // Multi-FASTA path (unchanged): emit `sweepga` invocations per pair.
+        let mut pairs: Vec<(String, String)> = Vec::new();
+        for i in 0..args.files.len() {
+            for j in (i + 1)..args.files.len() {
+                pairs.push((args.files[i].clone(), args.files[j].clone()));
+            }
+        }
         let bin = std::env::current_exe()
             .unwrap_or_else(|_| std::path::PathBuf::from("sweepga"));
         let cfg = joblist::JoblistEmitConfig {
             sweepga_bin: &bin,
-            output_dir: Path::new(&out_dir),
+            output_dir: out_dir_path,
             threads: args.threads,
             extra_flags: &[],
-        };
-        let mut out: Box<dyn std::io::Write> = match &args.output_file {
-            Some(f) => Box::new(std::fs::File::create(f)?),
-            None => Box::new(std::io::stdout()),
         };
         joblist::write_pair_commands(&pairs, &cfg, &mut out)?;
         return Ok(());

--- a/src/main.rs
+++ b/src/main.rs
@@ -929,6 +929,7 @@ fn align_multiple_fastas(
                 map_pct_identity.clone(),
                 tempdir.map(String::from),
                 wfmash_density,
+                None, // pairs_file: CLI batch path doesn't plumb pair selection
             )),
             _ => Box::new(batch_align::FastGABatchAligner::new(
                 frequency,

--- a/src/main.rs
+++ b/src/main.rs
@@ -826,43 +826,73 @@ fn read_fasta_names_and_lengths(fasta_path: &Path) -> Result<(Vec<String>, Vec<u
     Ok((names, lengths))
 }
 
-/// For a single PanSN-named FASTA, return the sparsified list of
-/// `(target_haplotype, query_haplotype)` key pairs that `--joblist` should
-/// emit wfmash commands for.
+/// Across one or more PanSN-named input FASTAs, return the sparsified
+/// list of `WfmashPansnJob`s that `--joblist` should emit wfmash
+/// commands for.
 ///
-/// Every haplotype is also emitted as a self-pair `(hap, hap)` so the
-/// downstream aligner runs intra-haplotype too (wfmash's default group-
-/// prefix behavior skips those internally; including them keeps the
-/// joblist semantically explicit and harmless).
-fn pansn_joblist_hap_pairs(
-    fasta: &Path,
+/// - Single-FASTA input: `target_fasta == query_fasta` for every job, and
+///   wfmash's self-map form is emitted.
+/// - Multi-FASTA input: each job's `target_fasta` / `query_fasta` point
+///   at whichever input FASTA contains the job's haplotype's contigs.
+///   When a haplotype spans multiple FASTAs (rare), the first-seen FASTA
+///   wins.
+///
+/// Every haplotype is also emitted as a self-pair so intra-haplotype
+/// alignments are explicit in the joblist (wfmash's `-Y` group-prefix
+/// may internally skip them; keeping them in the list is harmless and
+/// gives downstream orchestration a complete enumeration).
+///
+/// Returns an empty Vec when none of the input FASTAs carry PanSN
+/// structure — signal for the caller to fall back to the legacy
+/// per-file-pair `sweepga` joblist flow.
+fn pansn_joblist_jobs(
+    fastas: &[String],
     aln: &AlnArgs,
-) -> Result<Vec<(String, String)>> {
-    use crate::pansn::{group_indices_by_pansn, PanSnLevel};
-    let (names, _lengths) = read_fasta_names_and_lengths(fasta)?;
-    let name_refs: Vec<&str> = names.iter().map(|s| s.as_str()).collect();
-    let hap_groups = group_indices_by_pansn(name_refs.iter().copied(), PanSnLevel::Haplotype);
-    let hap_keys: Vec<String> = hap_groups
+) -> Result<Vec<joblist::WfmashPansnJob>> {
+    use crate::pansn::{extract_pansn_key, group_indices_by_pansn, PanSnLevel};
+    use std::path::PathBuf;
+
+    // Collect all contigs across all files, tagged with their source FASTA.
+    let mut all_names: Vec<String> = Vec::new();
+    let mut all_files: Vec<PathBuf> = Vec::new();
+    for f in fastas {
+        let (names, _lens) = read_fasta_names_and_lengths(Path::new(f))?;
+        for n in names {
+            all_names.push(n);
+            all_files.push(PathBuf::from(f));
+        }
+    }
+    if all_names.is_empty() {
+        return Ok(Vec::new());
+    }
+    let name_refs: Vec<&str> = all_names.iter().map(|s| s.as_str()).collect();
+
+    // Per-contig haplotype key, and per-haplotype representative file.
+    let hap_of: Vec<String> = name_refs
         .iter()
-        .filter_map(|g| {
-            g.first().and_then(|&i| {
-                crate::pansn::extract_pansn_key(&names[i], PanSnLevel::Haplotype)
-                    .or_else(|| Some(names[i].clone()))
-            })
-        })
+        .map(|n| extract_pansn_key(n, PanSnLevel::Haplotype).unwrap_or_else(|| (*n).to_string()))
         .collect();
-    if hap_keys.is_empty() {
-        anyhow::bail!("No sequences detected in {}", fasta.display());
+    let hap_groups = group_indices_by_pansn(name_refs.iter().copied(), PanSnLevel::Haplotype);
+    // If the input has no PanSN structure (every contig is its own
+    // haplotype), signal fallback to the legacy flow.
+    if hap_groups.len() == all_names.len() {
+        return Ok(Vec::new());
+    }
+    let mut hap_file: std::collections::BTreeMap<String, PathBuf> =
+        std::collections::BTreeMap::new();
+    for g in &hap_groups {
+        if let Some(&first) = g.first() {
+            let key = hap_of[first].clone();
+            hap_file.entry(key).or_insert_with(|| all_files[first].clone());
+        }
     }
 
-    // Build contig-level sketches only when the strategy actually needs
-    // distances. Sketch-free strategies (None / Random / WfmashDensity) use
-    // the no-sketch fast path.
+    // Sparsify at haplotype granularity. Sketch-based strategies read
+    // per-contig sequences; sketch-free strategies skip that.
     let mash_params = knn_graph::MashParams {
         kmer_size: aln.mash_kmer_size,
         sketch_size: aln.mash_sketch_size,
     };
-
     let contig_pair_indices: Vec<(usize, usize)> = match &aln.sparsify {
         knn_graph::SparsificationStrategy::None
         | knn_graph::SparsificationStrategy::Random(_)
@@ -874,16 +904,16 @@ fn pansn_joblist_hap_pairs(
             )
         }
         _ => {
-            // Sketch-based strategies need per-contig sequences; read them
-            // in one pass.
-            let sequences = read_fasta_sequences_for_sketching(fasta)?;
-            let seq_bytes: Vec<&[u8]> = sequences.iter().map(|s| s.as_slice()).collect();
+            let mut sequences: Vec<Vec<u8>> = Vec::with_capacity(all_names.len());
+            for f in fastas {
+                let mut seqs = read_fasta_sequences_for_sketching(Path::new(f))?;
+                sequences.append(&mut seqs);
+            }
             let sketches = mash::compute_sketches_parallel(
                 &sequences,
                 mash_params.kmer_size,
                 mash_params.sketch_size,
             );
-            let _ = seq_bytes;
             knn_graph::select_pairs_haplotype_aware(
                 &name_refs,
                 &sketches,
@@ -893,17 +923,7 @@ fn pansn_joblist_hap_pairs(
         }
     };
 
-    // Collapse contig-pair output back to haplotype keys. expand_haplotype_pairs
-    // emits every contig pair including intra-haplotype; the user of the
-    // wfmash-per-hap joblist only wants unique haplotype-pair keys.
-    // Per-contig → per-hap key.
-    let hap_of: Vec<String> = name_refs
-        .iter()
-        .map(|n| {
-            crate::pansn::extract_pansn_key(n, PanSnLevel::Haplotype)
-                .unwrap_or_else(|| (*n).to_string())
-        })
-        .collect();
+    // Collapse contig-pair output to unique haplotype-pair jobs.
     let mut seen: std::collections::BTreeSet<(String, String)> =
         std::collections::BTreeSet::new();
     for (i, j) in contig_pair_indices {
@@ -915,12 +935,27 @@ fn pansn_joblist_hap_pairs(
         };
         seen.insert(pair);
     }
-    // Always include each haplotype as a self-pair so intra-haplotype
-    // alignments are represented explicitly in the joblist.
-    for k in &hap_keys {
+    // Intra-haplotype self-pairs, always represented.
+    for k in hap_file.keys() {
         seen.insert((k.clone(), k.clone()));
     }
-    Ok(seen.into_iter().collect())
+
+    let empty_path = PathBuf::new();
+    let mut jobs: Vec<joblist::WfmashPansnJob> = Vec::with_capacity(seen.len());
+    for (target_hap, query_hap) in seen {
+        let target_fasta = hap_file.get(&target_hap).cloned().unwrap_or_default();
+        let query_fasta = hap_file.get(&query_hap).cloned().unwrap_or_default();
+        if target_fasta == empty_path || query_fasta == empty_path {
+            continue;
+        }
+        jobs.push(joblist::WfmashPansnJob {
+            target_hap,
+            query_hap,
+            target_fasta,
+            query_fasta,
+        });
+    }
+    Ok(jobs)
 }
 
 /// Read FASTA sequences (plain / bgzf) into a `Vec<Vec<u8>>` (one per
@@ -2660,15 +2695,19 @@ fn main() -> Result<()> {
         vec![]
     };
 
-    // --joblist: emit one shell command per pair and exit. Two modes:
+    // --joblist: emit one shell command per haplotype-pair job and exit.
     //
-    //   * Multi-FASTA input: emit a standalone `sweepga` invocation per
-    //     unordered file pair `(i,j)`. The existing flow.
-    //   * Single PanSN-named FASTA: group contigs by `SAMPLE#HAPLOTYPE`,
-    //     sparsify at haplotype granularity, and emit one
-    //     `wfmash -T <hap_i> -Q <hap_j>` command per selected pair. The
-    //     emitted commands reuse the single input file on both sides;
-    //     wfmash filters to the relevant contigs via its prefix flags.
+    // Works on one or many PanSN-named FASTAs. All input FASTAs are
+    // scanned for `SAMPLE#HAPLOTYPE#CONTIG` names, haplotypes are
+    // sparsified per the `--sparsify` strategy, and one
+    // `wfmash -T <hap_i> -Q <hap_j> target.fa [query.fa]` command is
+    // emitted per selected haplotype pair. wfmash's prefix filters mean
+    // the input FASTA(s) don't need pre-splitting; multi-FASTA inputs
+    // (e.g. one FASTA per haplotype) are handled transparently.
+    //
+    // Falls back to the legacy `sweepga QUERY TARGET` per-file-pair
+    // flow only when no PanSN haplotype structure is detectable in the
+    // input — which is the pre-PanSN-aware behavior sweepga already had.
     if args.aln.joblist {
         if args.files.is_empty() {
             anyhow::bail!("--joblist requires FASTA input");
@@ -2691,21 +2730,26 @@ fn main() -> Result<()> {
             None => Box::new(std::io::stdout()),
         };
 
-        if args.files.len() == 1 {
-            // Single-FASTA PanSN path: emit wfmash -T -Q per haplotype pair.
-            let fasta = Path::new(&args.files[0]);
-            let hap_pairs = pansn_joblist_hap_pairs(fasta, &args.aln)?;
+        // Try the PanSN haplotype-aware path first. Builds per-hap-pair
+        // wfmash jobs regardless of how many input FASTAs were provided.
+        let jobs = pansn_joblist_jobs(&args.files, &args.aln)?;
+        if !jobs.is_empty() {
             let cfg = joblist::WfmashPansnEmitConfig {
-                fasta,
                 output_dir: out_dir_path,
                 threads: args.threads,
                 block_length: args.aln.block_length.unwrap_or(0),
             };
-            joblist::write_wfmash_pansn_commands(&hap_pairs, &cfg, &mut out)?;
+            joblist::write_wfmash_pansn_commands(&jobs, &cfg, &mut out)?;
             return Ok(());
         }
 
-        // Multi-FASTA path (unchanged): emit `sweepga` invocations per pair.
+        // No PanSN structure detected — legacy per-file-pair sweepga flow.
+        if args.files.len() < 2 {
+            anyhow::bail!(
+                "--joblist on a single non-PanSN FASTA has no pairs to emit; \
+                 either provide PanSN-named input or pass 2+ FASTAs"
+            );
+        }
         let mut pairs: Vec<(String, String)> = Vec::new();
         for i in 0..args.files.len() {
             for j in (i + 1)..args.files.len() {

--- a/src/pansn.rs
+++ b/src/pansn.rs
@@ -98,6 +98,30 @@ where
     set.len().max(1)
 }
 
+/// Group sequence indices by their PanSN key at the requested level.
+///
+/// Returns a `Vec` of groups; each group is the list of input indices that
+/// share a key. Non-PanSN names (or names with no extractable key) fall back
+/// to the whole name, so every such contig becomes its own group — callers
+/// can therefore use this uniformly and treat "one group per name" as
+/// "input is not PanSN".
+///
+/// Ordering is stable: groups are sorted by their PanSN key, which makes the
+/// output reproducible across runs. Indices within each group keep their
+/// input order.
+pub fn group_indices_by_pansn<'a, I>(names: I, level: PanSnLevel) -> Vec<Vec<usize>>
+where
+    I: IntoIterator<Item = &'a str>,
+{
+    use std::collections::BTreeMap;
+    let mut map: BTreeMap<String, Vec<usize>> = BTreeMap::new();
+    for (i, name) in names.into_iter().enumerate() {
+        let key = extract_pansn_key(name, level).unwrap_or_else(|| name.to_string());
+        map.entry(key).or_default().push(i);
+    }
+    map.into_values().collect()
+}
+
 /// Count unique PanSN haplotypes across one or more FASTA files.
 pub fn count_haplotypes<P: AsRef<Path>>(fasta_paths: &[P]) -> Result<usize> {
     let mut haplotypes: HashSet<String> = HashSet::new();


### PR DESCRIPTION
## Why

`impg` pins sweepga at `04f9edb`, the tip of `pansn-sparsification`. That commit is not reachable from `main`, so `main` and the revision impg actually uses had drifted apart. This PR brings the branch onto `main` and then bumps `fastga-rs`.

## What

1. Merge `pansn-sparsification` into `main`. It is a clean merge, no conflicts. It adds:
   - PanSN haplotype sparsification and single-FASTA joblists
   - multi-FASTA PanSN joblist support
   - `pairs_file` plumbing through `WfmashBatchAligner`, so pair sparsification and batching compose
2. Update `fastga-rs` to `eb50026` (pangenome/fastga-rs#11).

## Why the fastga-rs bump matters

`fastga-rs` patched ONElib to honour `$TMPDIR` but left the destination buffer at 64 bytes. A `$TMPDIR` longer than 46 characters overflowed the stack, so `FAtoGDB` aborted with `*** buffer overflow detected ***`.

impg sets `TMPDIR` to its temp directory, which defaults to the current directory. Any user working in a deep path therefore lost `impg graph` and `impg query -o gfa` completely. Reproduced on 7 yeast chrV genomes: the run failed in a 90-character directory and finished in 278 seconds in `/tmp/impgt`.